### PR TITLE
Added Keyboard Shortcut to open QR-Code

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab2QR",
   "short_name": "Tab2QR",
   "author": "James Shih",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A minimalist browser extesion to send the page you are currently viewing to your mobile device.",
 
   "icons": {
@@ -18,6 +18,15 @@
     },
     "default_title": "Tab2QR",
     "default_popup": "popup.html"
+  },
+
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Q",
+        "mac": "MacCtrl+Q"
+      }
+    }
   },
 
   "permissions":[

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Tab2QR",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Send the page you are currently viewing to your mobile device.",
   "repository": "IFS49F/Tab2QR",
   "author": {


### PR DESCRIPTION
## Feature
- Added the keyboard shortcut Ctrl+Q to open the QR-Code popup. This simplifies the process and saves time when creating the QR-Code.

## Changes
Added 
```json
 "commands": {
    "_execute_browser_action": {
      "suggested_key": {
        "default": "Ctrl+Q",
        "mac": "MacCtrl+Q"
      }
    }
  }
```
to manifest.json